### PR TITLE
Template parameters can have blank Default.

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,9 +30,7 @@ type ParameterItem struct {
 }
 
 type ParsedParameterSpec struct {
-	Type        string `yaml:"Type"`
-	Description string `yaml:"Description"`
-	Default     string `yaml:"Default"`
+	Default *string `yaml:"Default",omitempty`
 }
 
 type ParsedTemplate struct {
@@ -109,7 +107,7 @@ func getJsonForInput(input *Input) ([]byte, error) {
 
 	specs := make(map[string]ParameterSpec)
 	for name, parsed := range t.Parameters {
-		specs[name] = ParameterSpec{Name: name, HasDefault: parsed.Default != ""}
+		specs[name] = ParameterSpec{Name: name, HasDefault: parsed.Default != nil}
 	}
 
 	if err := validateParameters(input.Parameters, specs); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -109,6 +109,15 @@ func TestDeployScenario(t *testing.T) {
 	}
 }
 
+func TestBlankDefault(t *testing.T) {
+	input := &Input{
+		TemplateBody:   []byte("Parameters:\n  Foo:\n    Default: \"\"\n"),
+		AcceptDefaults: true,
+	}
+	actual := mustGetParameterItems(t, input)
+	assert.Equal(t, 0, len(actual))
+}
+
 func mustGetParameterItems(t *testing.T, input *Input) []ParameterItem {
 	j, err := getJsonForInput(input)
 	require.NoError(t, err)


### PR DESCRIPTION
Duplicate of #5 but I forgot to push this commit four months ago — sorry @sdemontfort 🤦‍♂️ 

Fixes #4 where Defaults that are `""` in the CloudFormation template are ignored.
Closes #5.