### PR TITLE
JSON output contains ParameterValue XOR UsePreviousValue

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,9 +24,19 @@ type Input struct {
 }
 
 type ParameterItem struct {
+	ParameterKey     string
+	ParameterValue   string
+	UsePreviousValue bool
+}
+
+type ParameterItemWithValue struct {
+	ParameterKey   string `json:"ParameterKey"`
+	ParameterValue string `json:"ParameterValue"`
+}
+
+type ParameterItemUsePrevious struct {
 	ParameterKey     string `json:"ParameterKey"`
-	ParameterValue   string `json:"ParameterValue,omitempty"`
-	UsePreviousValue bool   `json:"UsePreviousValue,omitempty"`
+	UsePreviousValue bool   `json:"UsePreviousValue"`
 }
 
 type ParsedParameterSpec struct {
@@ -176,4 +186,18 @@ func validateParameters(params map[string]string, specs map[string]ParameterSpec
 		return fmt.Errorf("specified parameters not in template: %s", strings.Join(unexpected, ", "))
 	}
 	return nil
+}
+
+func (p ParameterItem) MarshalJSON() ([]byte, error) {
+	if p.UsePreviousValue {
+		return json.Marshal(ParameterItemUsePrevious{
+			ParameterKey:     p.ParameterKey,
+			UsePreviousValue: true,
+		})
+	} else {
+		return json.Marshal(ParameterItemWithValue{
+			ParameterKey:   p.ParameterKey,
+			ParameterValue: p.ParameterValue,
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ type Input struct {
 }
 
 type ParameterItem struct {
-	ParameterKey     string `json:"ParameterKey,omitempty"`
+	ParameterKey     string `json:"ParameterKey"`
 	ParameterValue   string `json:"ParameterValue,omitempty"`
 	UsePreviousValue bool   `json:"UsePreviousValue,omitempty"`
 }

--- a/main_test.go
+++ b/main_test.go
@@ -118,6 +118,44 @@ func TestBlankDefault(t *testing.T) {
 	assert.Equal(t, 0, len(actual))
 }
 
+func TestJsonUsePreviousValue(t *testing.T) {
+	input := &Input{
+		TemplateBody: []byte("Parameters:\n  Foo:\n    Description: \"may be blank\"\n"),
+	}
+	j := mustGetJson(t, input)
+	assert.Contains(t, j, "ParameterKey")
+	assert.NotContains(t, j, "ParameterValue")
+	assert.Contains(t, j, "UsePreviousValue")
+}
+
+func TestJsonNonBlankParameterFileValue(t *testing.T) {
+	input := &Input{
+		TemplateBody:   []byte("Parameters:\n  Foo:\n    Description: \"may be blank\"\n"),
+		ParametersYAML: []byte("---\nFoo: bar\n"),
+	}
+	j := mustGetJson(t, input)
+	assert.Contains(t, j, "ParameterKey")
+	assert.Contains(t, j, "ParameterValue")
+	assert.NotContains(t, j, "UsePreviousValue")
+}
+
+func TestJsonBlankParameterFileValue(t *testing.T) {
+	input := &Input{
+		TemplateBody:   []byte("Parameters:\n  Foo:\n    Description: \"may be blank\"\n"),
+		ParametersYAML: []byte("---\nFoo:\n"),
+	}
+	j := mustGetJson(t, input)
+	assert.Contains(t, j, "ParameterKey")
+	assert.Contains(t, j, "ParameterValue")
+	assert.NotContains(t, j, "UsePreviousValue")
+}
+
+func mustGetJson(t *testing.T, input *Input) string {
+	j, err := getJsonForInput(input)
+	require.NoError(t, err)
+	return string(j)
+}
+
 func mustGetParameterItems(t *testing.T, input *Input) []ParameterItem {
 	j, err := getJsonForInput(input)
 	require.NoError(t, err)


### PR DESCRIPTION
Previously for explicitly blank values, there was no ParameterValue in the
JSON.