### PR TITLE
Support !ParameterStore /foo/bar in parameters YAML files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "v2"
+  name = "github.com/sanathkr/go-yaml"
+  packages = ["."]
+  revision = "ed9d249f429b3f5a69f80a7abef6bfce81fef894"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -22,15 +28,9 @@
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
-[[projects]]
-  name = "gopkg.in/yaml.v2"
-  packages = ["."]
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1c9686fdea86f74e75e14d32b0b6a3af7613adc7012ffc04a42a1f4ded96c1af"
+  inputs-digest = "9a401f253b71924b736117c50728f1e0647e101d9e1f6521b970b3e01c27205b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,10 +29,6 @@
   name = "github.com/stretchr/testify"
   version = "1.2.1"
 
-[[constraint]]
-  name = "gopkg.in/yaml.v2"
-  version = "2.2.1"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/cultureamp/cfparams/parameterstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -148,6 +149,20 @@ func TestJsonBlankParameterFileValue(t *testing.T) {
 	assert.Contains(t, j, "ParameterKey")
 	assert.Contains(t, j, "ParameterValue")
 	assert.NotContains(t, j, "UsePreviousValue")
+}
+
+func TestCustomYamlTags(t *testing.T) {
+	parameterstore.Fake(map[string]string{
+		"/path/to/secret": "hunter2",
+	})
+	input := &Input{
+		TemplateBody:   []byte("Parameters:\n  Secret:\n"),
+		ParametersYAML: []byte("Secret: !ParameterStore /path/to/secret\n"),
+	}
+	item := mustGetParameterItems(t, input)[0]
+	require.Equal(t, "Secret", item.ParameterKey)
+	require.Equal(t, "hunter2", item.ParameterValue)
+	require.Equal(t, false, item.UsePreviousValue)
 }
 
 func mustGetJson(t *testing.T, input *Input) string {

--- a/parameters.go
+++ b/parameters.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -32,7 +33,9 @@ type ParameterItemUsePrevious struct {
 type parameterStoreUnmarshaler struct{}
 
 func (t *parameterStoreUnmarshaler) UnmarshalYAMLTag(tag string, fieldValue reflect.Value) reflect.Value {
-	value, err := parameterstore.Get(fieldValue.String())
+	name := fieldValue.String()
+	log.New(os.Stderr, "", log.LstdFlags).Printf("ParameterStore: GetParameter(%#v)\n", name)
+	value, err := parameterstore.Get(name)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		value = "" // crash instead?

--- a/parameters.go
+++ b/parameters.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type ParameterItem struct {
+	ParameterKey     string
+	ParameterValue   string
+	UsePreviousValue bool
+}
+
+// JSON representation for parameter with ParameterValue
+type ParameterItemWithValue struct {
+	ParameterKey   string `json:"ParameterKey"`
+	ParameterValue string `json:"ParameterValue"`
+}
+
+// JSON representation for parameter with UsePreviousValue
+type ParameterItemUsePrevious struct {
+	ParameterKey     string `json:"ParameterKey"`
+	UsePreviousValue bool   `json:"UsePreviousValue"`
+}
+
+func parseParameters(input *Input) error {
+	input.Parameters = make(map[string]string)
+
+	// Parameters from YAML file
+	err := yaml.Unmarshal(input.ParametersYAML, input.Parameters)
+	if err != nil {
+		return err
+	}
+
+	// Parameters from CLI
+	for _, kv := range input.ParametersCLI {
+		pair := strings.SplitN(kv, "=", 2)
+		if len(pair) != 2 {
+			return fmt.Errorf("expected Key=value, got %s", pair)
+		}
+		input.Parameters[pair[0]] = pair[1]
+	}
+
+	return nil
+}
+
+func validateParameters(params map[string]string, specs map[string]ParameterSpec) error {
+	unexpected := []string{}
+	for name, _ := range params {
+		if _, ok := specs[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	if len(unexpected) > 0 {
+		return fmt.Errorf("specified parameters not in template: %s", strings.Join(unexpected, ", "))
+	}
+	return nil
+}
+
+func (p ParameterItem) MarshalJSON() ([]byte, error) {
+	if p.UsePreviousValue {
+		return json.Marshal(ParameterItemUsePrevious{
+			ParameterKey:     p.ParameterKey,
+			UsePreviousValue: true,
+		})
+	} else {
+		return json.Marshal(ParameterItemWithValue{
+			ParameterKey:   p.ParameterKey,
+			ParameterValue: p.ParameterValue,
+		})
+	}
+}

--- a/parameterstore/store.go
+++ b/parameterstore/store.go
@@ -1,0 +1,43 @@
+package parameterstore
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+var fakes map[string]string
+
+func Fake(params map[string]string) {
+	fakes = params
+}
+
+func Get(name string) (string, error) {
+	if fakes == nil {
+		return getReal(name)
+	} else {
+		return getFake(name)
+	}
+}
+
+func getFake(name string) (string, error) {
+	if val, ok := fakes[name]; ok {
+		return val, nil
+	} else {
+		return "", errors.New("No fake parameter for " + name)
+	}
+}
+
+func getReal(name string) (string, error) {
+	client := ssm.New(session.Must(session.NewSession(&aws.Config{})))
+	output, err := client.GetParameter(&ssm.GetParameterInput{
+		Name:           &name,
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return "", err
+	}
+	return *output.Parameter.Value, nil
+}

--- a/template.go
+++ b/template.go
@@ -1,0 +1,29 @@
+package main
+
+import yaml "gopkg.in/yaml.v2"
+
+type ParsedTemplate struct {
+	Parameters map[string]ParsedParameterSpec `yaml:"Parameters"`
+}
+
+type ParsedParameterSpec struct {
+	Default *string `yaml:"Default",omitempty`
+}
+
+type ParameterSpec struct {
+	Name       string
+	HasDefault bool
+}
+
+func parseTemplate(body []byte) (map[string]ParameterSpec, error) {
+	var t ParsedTemplate
+	err := yaml.Unmarshal(body, &t)
+	if err != nil {
+		return nil, err
+	}
+	specs := make(map[string]ParameterSpec)
+	for name, parsed := range t.Parameters {
+		specs[name] = ParameterSpec{Name: name, HasDefault: parsed.Default != nil}
+	}
+	return specs, nil
+}


### PR DESCRIPTION
Add support for YAML parameter files looking up values from [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html).

```yaml
DatabaseHost: db.example.org
DatabaseUser: app
DatabasePassword: !ParameterStore /example/db/password
```

`cfparams` will fetch the parameter named `/example/db/password`, and use the resulting value for `DatabasePassword`. AWS credentials, region etc are sourced from the environment / instance role / etc in the standard AWS SDK ways.

This PR includes high-churn refactor; viewing just the ParameterStore-specific commit will show the implementation more clearly.

The YAML syntax `DatabasePassword: !ParameterStore /example/db/password` makes use of a YAML feature called [tags](http://yaml.org/spec/1.2/spec.html#id2761292) (specifically, "local tags"), where `!ParameterStore` is the tag telling the parser the value is a custom type. None of the popular Go YAML parsers support tags, but https://github.com/sanathkr/go-yaml/commit/ed9d249f429b3f5a69f80a7abef6bfce81fef894 forks the defacto standard https://github.com/go-yaml/yaml and adds support. [Apparently](https://github.com/go-yaml/yaml/pull/332#issuecomment-372501823) custom tags will be supported in v3 of github.com/go-yaml/yaml at which point cfparams can switch back.

Note that if a CloudFormation parameter is a secret, it should be declared as `NoEcho: true` in the template. `cfparams` could perhaps be adapted to warn when a Parameter Store SecureString is passed to a parameter that isn't `NoEcho`. I'll save that for another PR.