### PR TITLE
Add capability to read additional tags from CLI

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	yaml "github.com/sanathkr/go-yaml"
 )
@@ -13,7 +15,22 @@ type jsonItem struct {
 
 func getJsonForInputTags(input *Input) ([]byte, error) {
 	data := map[string]string{}
-	yaml.Unmarshal(input.TagsBody, &data)
+
+	// Tags from YAML file
+	err := yaml.Unmarshal(input.TagsBody, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Tags from CLI
+	for _, kv := range input.ParametersCLI {
+		pair := strings.SplitN(kv, "=", 2)
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("expected key=value, got %s", pair)
+		}
+		data[pair[0]] = pair[1]
+	}
+
 	items := []jsonItem{}
 	for key, value := range data {
 		items = append(items, jsonItem{Key: key, Value: value})


### PR DESCRIPTION
This PR adds the capability to read extra tags on the CLI input as positional arguments if you're using the --tags parameter. This will allow simple overriding of tags defined in the tags file just like it does when using this functionality with cfn parameters.

e.g.
`tags-test.yaml`
```yaml
asset: buildkite
workload: delivery
buildkite-group: build-test
```

on the CLI:
```bash
> cfparams --tags=tags-test.yaml buildkite-group=build-pylons message=extra-tag
[
  {
    "Key": "buildkite-group",
    "Value": "build-pylons"
  },
  {
    "Key": "message",
    "Value": "extra-tag"
  },
  {
    "Key": "asset",
    "Value": "buildkite"
  },
  {
    "Key": "workload",
    "Value": "delivery"
  }
]
```