### PR TITLE
chore: Distribute ARM releases via GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version_tag: ${{ steps.tag-release.outputs.version_tag }}
+
+    steps:
+      - name: Protect parameters
+        uses: cultureamp/protect-event-parameters@v2
+        with:
+          allowlist: "originating_url,release_version,release_type"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - name: Tag release
+        id: tag-release
+        run: |
+          bin/ci_tag_version "${{ github.event.client_payload.release_version }}" "${{ github.event.client_payload.release_type }}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
+
+  publish:
+    needs: tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Protect parameters
+        uses: cultureamp/protect-event-parameters@v2
+        with:
+          allowlist: "originating_url,release_version,release_type"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Release cfparams
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --debug
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,25 @@
+builds:
+  - binary: cfparams
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+checksum:
+  name_template: "checksums.txt"
+
+archives:
+  - format: "binary"
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  use: github-native
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/bin/ci_tag_version
+++ b/bin/ci_tag_version
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+function main() {
+    local release_version="${1}"
+    local release_type="${2}"
+    local commit_sha;
+    local version_tag;
+
+    commit_sha=$(git rev-parse HEAD)
+
+    echo "Auto-generating version tag ..."
+
+    echo "Current HEAD: $commit_sha"
+
+    local version_options=()
+
+    if [ -n "$release_version" ]; then
+        echo "Override version: '${release_version}'"
+        version_options+=('--release-as' "${release_version}")
+    fi;
+
+    if [ -n "$release_type" ] && [ "$release_type" != "stable" ]; then
+        echo "Using pre-release designator: '${release_type}'"
+        version_options+=("--prerelease" "${release_type}")
+    fi
+
+    configure_git
+
+    # analyses history and creates a tag in the local repo
+    npx standard-version "${version_options[@]}"
+
+    version_tag="$(git describe --abbrev=0)"
+
+    echo "standard_version created version '${version_tag}' for this release"
+
+    # create the tag in the origin repo
+    # uses the REST API for token authentication
+    "$DIR/tag_github" "$version_tag" "$commit_sha"
+
+    # set the version tag as an output of this step
+    echo "::set-output name=version_tag::$version_tag"
+}
+
+function configure_git() {
+    git config --global user.email "actions@github.com"
+    git config --global user.name "gh-actions"
+}
+
+main "$@"

--- a/bin/tag_github
+++ b/bin/tag_github
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+#
+# tag_github [tag] [commit]
+#
+# Create a tag in the Github remote repo using curl. This allows the use of a
+# personal access token with write capabilities instead of requiring a
+# writeable deploy key.
+#
+# - tag: the name of the tag to create
+# - commit: the hash of the commit at which the tag should be created.
+#
+# Expects GITHUB_TOKEN as an environment variable.
+#
+
+function main() {
+    local tag="${1}"
+    local commit="${2}"
+
+    if [ -z "$GITHUB_TOKEN" ]; then
+        >&2 echo "❌ Environment variable GITHUB_TOKEN is required"
+        exit 1
+    fi
+
+    # key is interpolated by jq, not bash
+    # shellcheck disable=SC2016
+    local tag_payload_template='
+    {
+        "tag": $tag,
+        "message": $message,
+        "object": $commit,
+        "type": "commit"
+    }'
+    # shellcheck disable=SC2016
+    local ref_payload_template='
+    {
+        "ref": $ref,
+        "sha": $tag_hash
+    }'
+
+    local payload;
+
+    # creating a tag using REST: https://docs.github.com/en/rest/reference/git#create-a-tag-object
+
+    # create the tag
+
+    payload="$(jq --null-input \
+        --arg tag "${tag}" \
+        --arg message "Version ${tag}" \
+        --arg commit "${commit}" \
+        "$tag_payload_template")"
+
+    tag_hash=$(post "cultureamp/cfparams" "git/tags" "${payload}" | jq -r '.sha')
+
+    echo "Created tag ${tag}: commit sha=${tag_hash}"
+
+    # associate a ref with the tag
+
+    payload="$(jq --null-input \
+        --arg ref "refs/tags/${tag}" \
+        --arg tag_hash "${tag_hash}" \
+        "$ref_payload_template"
+    )"
+
+    post "cultureamp/cfparams" "git/refs" "${payload}"
+}
+
+function post() {
+    local repo="${1}"
+    local action="${2}"
+    local payload="${3}"
+
+    curl \
+        --fail \
+        -X POST \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/${repo}/${action}" \
+        -d "$payload"
+}
+
+main "$@"


### PR DESCRIPTION
# Purpose 🎯 

These changes add the use of `GoReleaser` to `cfparams` so that we can iteratively release updates for the project. This project has been manually released since its inception.

# Context 🧠 

- Part of an effort to add a releasing workflow to `cfprams`.
- [CSRE-2483](https://cultureamp.atlassian.net/browse/CSRE-2483)

[CSRE-2483]: https://cultureamp.atlassian.net/browse/CSRE-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ