### PR TITLE
chore: Add autosilk-cli.yaml

### DIFF
--- a/autosilk-cli.yaml
+++ b/autosilk-cli.yaml
@@ -1,0 +1,11 @@
+project-name: cfparams-reporting
+pipeline-slug: cfparams
+cluster-name: cfparams
+github-repo: cfparams
+commit-branch: cfparams-autosilk-init
+create-source-security-groups: false
+create-ecr-repos: false
+restricted-accounts: false
+environments:
+secrets:
+  - cfparams/GITHUB_TOKEN


### PR DESCRIPTION
# Purpose 🎯

This allows `cfparams` to be intiliased by Backstage. This will enable a Buildkite pipeline, and _should_ allow the deploy role access to a Secrets Manager secret that will host the GITHUB_TOKEN.

# Context 🧠 

- The intention for this is to enable us setting up a Buildkite pipeline to trigger a release process for `cfparams` using `goreleaser`. Refer to WiP in: https://github.com/cultureamp/cfparams/pull/18