### PR TITLE
fix(autosilk): environment and policies key are required

### DIFF
--- a/autosilk-cli.yaml
+++ b/autosilk-cli.yaml
@@ -7,5 +7,8 @@ create-source-security-groups: false
 create-ecr-repos: false
 restricted-accounts: false
 environments:
+  - continuous-integration
+policies:
+  - useCdK
 secrets:
   - cfparams/GITHUB_TOKEN


### PR DESCRIPTION
Follow up to #19, `autosilk` workflow threw an error (pictured) stating the environments and policies were required.

![image](https://user-images.githubusercontent.com/41095688/236376653-c03245fa-5f17-477b-8ae5-ff18ec70884c.png)
