### PR TITLE
ci: Releases are pushed to Culture Amp Homebrew tap

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eou pipefail
+
+if [ "$BUILDKITE_BRANCH" = "master" ]; then
+  branch_type="master"
+  build_agent="build-restricted"
+else
+  branch_type="development"
+  build_agent="build-unrestricted"
+fi
+
+export BRANCH_TYPE="$branch_type"
+export BUILD_ROLE="arn:aws:iam::226140413739:role/build-role-$branch_type-cfparams"
+export BUILD_AGENT="$build_agent"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,34 @@
+steps:
+  - block: "Release build"
+    branches:
+      - master
+    fields:
+      - select: "Prerelease?"
+        key: "release-type"
+        options:
+          - label: "Stable"
+            value: "stable"
+          - label: "Alpha"
+            value: "alpha"
+          - label: "Beta"
+            value: "beta"
+        required: true
+        default: "stable"
+      - text: "Version number"
+        key: "release-version"
+        hint: "(optional) forced version (X.X.X)"
+        required: false
+
+  - label: ":github: Trigger release"
+    branches:
+      - master
+    command: "bin/ci_trigger_release"
+    agents:
+      queue: ${BUILD_AGENT}
+    plugins:
+      - cultureamp/aws-assume-role:
+          role: ${BUILD_ROLE}
+          duration: 900 # limit role assumption validity to 15 minutes
+      - cultureamp/aws-sm#v2.2.0:
+          env:
+            GITHUB_TOKEN: /cfparams/GITHUB_TOKEN

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  # Release from master branch will be triggered by Buildkite,
+  # passing a signing key and allowing a release-ready
+  # build to be created.
+  repository_dispatch:
+    types: release-build
 
 jobs:
   tag:
@@ -32,7 +34,7 @@ jobs:
         run: |
           bin/ci_tag_version "${{ github.event.client_payload.release_version }}" "${{ github.event.client_payload.release_type }}"
         env:
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
+          GITHUB_TOKEN: ${{ github.event.client_payload.github_write_token }}
 
   publish:
     needs: tag
@@ -61,4 +63,4 @@ jobs:
           version: latest
           args: release --clean --debug
         env:
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
+          GITHUB_TOKEN: ${{ github.event.client_payload.github_write_token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,4 +22,40 @@ snapshot:
 
 changelog:
   use: github-native
+  sort: asc
+  filters:
+    exclude:
+      - "^build:"
+      - "^ci:"
+      - "^docs:"
+      - "^test:"
+
+brews:
+  - name: cfparams
+    tap:
+      owner: cultureamp
+      name: homebrew-tap
+    commit_author:
+      name: cultureamp-ci
+      email: 36431315+cultureamp-ci@users.noreply.github.com
+
+    folder: Formula
+    homepage: https://github.com/cultureamp/cfparams
+    description: Wrangle parameters for AWS CloudFormation
+
+    test: |
+      minimal = testpath/"minimal.yaml"
+      minimal.write <<~EOS
+        Parameters:
+          TestParameter:
+            Type: String
+            Default: testvalue
+        Resources:
+          S3Bucket:
+            Type: AWS::S3::Bucket
+      EOS
+      system "#{bin}/cfparams --template=minimal.yaml"
+    install: |
+      bin.install "cfparams_{{ .Os }}_{{ .Arch }}" => "cfparams"
+
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/bin/ci_tag_version
+++ b/bin/ci_tag_version
@@ -22,6 +22,7 @@ function main() {
         version_options+=('--release-as' "${release_version}")
     fi;
 
+    # --prerelease for standard-version is broken, and any value but stable will not work
     if [ -n "$release_type" ] && [ "$release_type" != "stable" ]; then
         echo "Using pre-release designator: '${release_type}'"
         version_options+=("--prerelease" "${release_type}")

--- a/bin/ci_trigger_release
+++ b/bin/ci_trigger_release
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+SEMVER='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+# shellcheck source=shared.bash
+. "$DIR/shared.bash"
+
+trap finish EXIT
+
+main() {
+  local release_version;release_version="$(buildkite-agent meta-data get "release-version" --no-color --default "")"
+  local release_type;release_type="$(buildkite-agent meta-data get "release-type" --no-color)"
+
+  if [ -n "$release_version" ] && [[ ! "${release_version}" =~ ${SEMVER} ]]; then
+    echo >&2 "❌ Release version '${release_version}' must conform to semver (without prerelease): X.Y.Z. For example, '1.0.2'"
+    exit 1
+  fi
+
+  echo '+++ :github: Trigger release on Github ...'
+
+  # shellcheck disable=SC2153
+  trigger_repository_event \
+    "${GITHUB_TOKEN}" \
+    "${BUILDKITE_BUILD_URL}" \
+    "${release_version}" \
+    "${release_type}"
+
+  buildkite-agent annotate --style 'info' ":shipit: Release ${release_version} ${release_type} <a href='https://github.com/cultureamp/cfparams/actions'>triggered in Github Actions</a>."
+}
+
+trigger_repository_event() {
+    local github_write_token="$1"
+    local build_url="$2"
+    local release_version="$3"
+    local release_type="$4"
+
+    local repo_name="cfparams"
+    local payload
+
+    # Trigger a repo dispatch event. This will only trigger
+    # on the default branch of the target repository.
+    #
+    # The hook will return an error code if there is no action
+    # to execute.
+    #
+    # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
+
+    # variable names are interpolated by jq, not bash
+    #shellcheck disable=SC2016
+    local payload_template='
+    {
+        "event_type": "release-build",
+        "client_payload": {
+            "originating_url": $build_url,
+            "release_version": $release_version,
+            "release_type": $release_type,
+            "github_write_token": $github_write_token,
+        }
+    }'
+
+    local payload;
+
+    payload="$(jq --null-input \
+        --arg build_url "${build_url}" \
+        --arg release_version "${release_version}" \
+        --arg release_type "${release_type}" \
+        --arg github_write_token "${github_write_token}" \
+        --arg build_url "${build_url}" \
+        "${payload_template}")"
+
+    curl \
+      "https://api.github.com/repos/cultureamp/${repo_name}/dispatches" \
+      --fail \
+      -H "Accept: application/json" \
+      -H "Authorization: token ${github_write_token}" \
+      --request POST \
+      --data "${payload}"
+}
+
+main "$@"

--- a/bin/shared.bash
+++ b/bin/shared.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function inline_link() {
+  LINK=$(printf "url='%s'" "$1")
+
+  if [ $# -gt 1 ]; then
+    LINK=$(printf "$LINK;content='%s'" "$2")
+  fi
+
+  printf '\033]1339;%s\a\n' "$LINK"
+}
+
+function finish() {
+  # Did the previous command fail? Then make Buildkite
+  # auto-expand the build log for it.
+  if [ "$?" -gt 0 ]; then
+    echo "^^^ +++"
+  fi
+}


### PR DESCRIPTION
## Purpose 🎯 

These changes publish new versions of `cfparams` to our Culture Amp Homebrew tap. To achieve this, the release Github Actions workflow is triggered via Buildkite. This invocation method enables the ability to pass Github access tokens without having to define them within this repo's secrets repository. This means, we can continue to have our secrets defined in AWS Secrets Manager and not have anything special for these kinds of workflows.

## Context 🧠 

- Part of an effort to get ARM releases available to our engineers via Homebrew
- [CSRE-2483](https://cultureamp.atlassian.net/browse/CSRE-2483)


## Notes 📓 

- A PAT for this repository was made so that a `goreleaser` PR could be created, and merged without approval in our [Homebrew Tap](https://github.com/cultureamp/homebrew-tap).

- To test this, the default branch for the repo needed to be changed to this PR's branch. As well as extending the branch restrictions for the Buildkite pipeline.

- The archive method opts in to use binaries rather than zipping and tarring it. This required us to rename the file as part of the install phase. This is so that the "_<OS>_<arch>" suffix is dropped and the binary and we're just left with `cfparams` as the installed binary name.

[CSRE-2483]: https://cultureamp.atlassian.net/browse/CSRE-2483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ