### PR TITLE
chore: Deploy role is not required for cfparams

### DIFF
--- a/autosilk-cli.yaml
+++ b/autosilk-cli.yaml
@@ -8,7 +8,5 @@ create-ecr-repos: false
 restricted-accounts: false
 environments:
   - continuous-integration
-policies:
-  - useCdK
 secrets:
   - cfparams/GITHUB_TOKEN


### PR DESCRIPTION
## Purpose 🎯 

These changes remove the `useCdk` policy from `cfparams`. This is not needed because there is no need for a deploy role for `cfparams`. The inclusion of this configuration creates a deploy role in BIfS.

## Context 🧠 

- Bring `cfparams` autosilk configuration in line with the changes in https://github.com/cultureamp/base-infrastructure-for-services/pull/3068