### PR TITLE
project is cfparams, not reporting

### DIFF
--- a/autosilk-cli.yaml
+++ b/autosilk-cli.yaml
@@ -1,4 +1,4 @@
-project-name: cfparams-reporting
+project-name: cfparams
 pipeline-slug: cfparams
 cluster-name: cfparams
 github-repo: cfparams


### PR DESCRIPTION
This change correct the project name `cfparams-reporting` to `cfparams`.

The incorrect project name defines the name of the `cfparams` project in  BIfS, and this has inadvertently created resources as `cfparams-reporting`.