### PR TITLE
ci: upgrade goreleaser parameters

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release --clean --debug
+          version: "~> v2"
+          args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ github.event.client_payload.github_write_token }}


### PR DESCRIPTION
Remove deprecated CLI flag.

`--debug` has been deprecated for some time, and is now removed in favour of `--verbose`.

See [GoReleaser docs](https://goreleaser.com/deprecations/#-debug)