### PR TITLE
ci: add release notifier to pipeline

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -32,3 +32,10 @@ steps:
       - cultureamp/aws-sm#v2.2.0:
           env:
             GITHUB_TOKEN: /cfparams/GITHUB_TOKEN
+
+notify:
+  - slack:
+      channels:
+        - "#team_sre_foundations_alerts"
+      message: ":fyii: <!subteam^S03CQLT3G2J>: A new version of CFParams is ready to be released :shipit:"
+    if: 'build.branch == "main" && build.state == "blocked"'


### PR DESCRIPTION
Configured a Slack message to be sent to Team SRE Foundations when a new release is ready to be published. (Effectively, after every merge into `origin/main`.)

This notifier was added to ensure dependency upgrades are actually released, not just merged and forgotten/unreleased.