### PR TITLE
ci: use v6 queues

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -24,7 +24,7 @@ steps:
       - main
     command: "bin/ci_trigger_release"
     agents:
-      queue: ${BUILD_AGENT}
+      queue: ${BUILD_AGENT}-v6
     plugins:
       - cultureamp/aws-assume-role:
           role: ${BUILD_ROLE}


### PR DESCRIPTION
## Purpose
- Switch over to using v6-equivalent queues, to give us more confidence that v6 is working

## Context
- Part of SREF's health week of migrating to elastic stack v6

