### PR TITLE
ci: change to ARM build agents

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,4 +2,4 @@
 set -eou pipefail
 
 export BUILD_ROLE="arn:aws:iam::226140413739:role/build-role-master-cfparams"
-export BUILD_AGENT="build-restricted"
+export BUILD_AGENT="build-restricted-arm"


### PR DESCRIPTION
Changed the build agent from x86 to ARM because the latter is cheaper.